### PR TITLE
Added ignoring cases to monitored commands

### DIFF
--- a/src/main/java/com/minecraftdimensions/bungeechatfilter/PlayerChatListener.java
+++ b/src/main/java/com/minecraftdimensions/bungeechatfilter/PlayerChatListener.java
@@ -89,7 +89,7 @@ public class PlayerChatListener implements Listener {
     }
 
     public boolean isMonitoredCommand(String command){
-        return  Main.COMLIST.contains( command.substring( 1, command.length() ).split( " " )[0]);
+        return  Main.COMLIST.contains( command.substring( 1, command.length() ).split( " " )[0].toLowerCase());
     }
 
 }


### PR DESCRIPTION
I thought ignoring mixed case commands is a bug, so I added a .toLowerCase() conversion when checking against the list of commands in the config